### PR TITLE
Remove the postinstall script as it causes errors during installation as a dependency

### DIFF
--- a/change/@microsoft-fast-tooling-react-158de057-9d69-435c-8eeb-4478b9b7cb3a.json
+++ b/change/@microsoft-fast-tooling-react-158de057-9d69-435c-8eeb-4478b9b7cb3a.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Updates to package scripts to prevent needing to use --ignore-scripts to install the package",
+  "packageName": "@microsoft/fast-tooling-react",
+  "email": "7559015+janechu@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
   "license": "MIT",
   "private": true,
   "workspaces": [
-    "./packages/fast-tooling-react",
     "./packages/fast-tooling",
+    "./packages/fast-tooling-react",
     "./packages/fast-tooling-wasm"
   ],
   "repository": {

--- a/packages/fast-tooling-react/package.json
+++ b/packages/fast-tooling-react/package.json
@@ -23,7 +23,6 @@
     "clean:dist": "node ../../build/clean.js dist",
     "coverage": "jest --coverage",
     "prepublishOnly": "npm run clean:dist && npm run build",
-    "postinstall": "npm run clean:dist && npm run build",
     "prettier": "prettier --config ../../.prettierrc --write \"**/*.{ts,tsx,html}\"",
     "prettier:diff": "prettier --config ../../.prettierrc \"**/*.{ts,tsx,html}\" --list-different",
     "start": "webpack-dev-server --history-api-fallback --progress --config webpack.config.cjs",


### PR DESCRIPTION
# Pull Request

## 📖 Description

<!--- Provide some background and a description of your work. -->
The `postinstall` script is firing when the fast-tooling-react package is added as a dependency. To prevent this only the `prepare` script is utilized. It is unknown at this time why the change was made during migration.

Edit: well apparently it was because fast-tooling-react installs first even though fast-tooling is a dependency. Still looking for a solution.

## 👩‍💻 Reviewer Notes

<!---
Provide some notes for reviewers to help them provide targeted feedback and testing.
-->
Run installation locally to see if any issues arise.

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.